### PR TITLE
Fix Lychee pictures docker volume mount

### DIFF
--- a/Template/template.json
+++ b/Template/template.json
@@ -1502,7 +1502,7 @@
         "bind": "/portainer/Files/AppData/Config/Lychee"
       },
       {
-        "container": "/config",
+        "container": "/pictures",
         "bind": "/portainer/Pictures"
       }
     ],


### PR DESCRIPTION
Lychee pictures was bound erroneously to /config.
Portainer failed to deploy the template.

Changed to /pictures as indicated on docker documentation.