### PR TITLE
Removed tag on daapd

### DIFF
--- a/Template/template.json
+++ b/Template/template.json
@@ -627,7 +627,7 @@
     "name": "daapd",
     "description": "DAAP (iTunes) media server with support for AirPlay devices, Apple Remote (and compatibles), MPD and internet radio.",
     "logo": "https://raw.githubusercontent.com/linuxserver/beta-templates/master/lsiodev/img/daapd-icon.png",
-    "image": "linuxserver/daapd:latest",
+    "image": "linuxserver/daapd",
     "categories": [
       "Music"
     ],


### PR DESCRIPTION
Error retrieving daapd image. removed daapd:latest tag since it will automatically retrieve the correct image for arch.