### PR TITLE
Add Cloudflare DDNS and Calibre to templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ All templates are already configured to bind mount to various places on your dri
 - webgrabplus
 - znc
 - cloudflare-ddns
+- Calibre
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ All templates are already configured to bind mount to various places on your dri
 - unifi
 - webgrabplus
 - znc
+- cloudflare-ddns
 
 ## Contributing
 

--- a/Template/template.json
+++ b/Template/template.json
@@ -253,6 +253,22 @@
   },
   {
     "type": 1,
+    "title: "Calibre",
+    "name": "calibre",
+    "description": "Calibre is a powerful and easy to use e-book manager",
+    "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/calibre.png",
+    "image": "linuxserver/calibre",
+    "categories": [
+      "Tools",
+      "Books",
+      "Other"
+    ],
+    "platform": "linux"
+    "restart-policy": "unless-stopped"
+    
+  },  
+  {
+    "type": 1,
     "title": "Cloudflare DDNS",
     "name": "cloudflare-ddns",
     "description": "This small Alpine Linux based Docker image will allow you to use the free CloudFlare DNS Service as a Dynamic DNS Provider (DDNS).",

--- a/Template/template.json
+++ b/Template/template.json
@@ -270,8 +270,10 @@
       "8081:8081"
     ],
     "volumes": [
-      "container": "/config",
-      "bind": "/portainer/Files/AppData/Config/Calibre"
+      {
+        "container": "/config",
+        "bind": "/portainer/Files/AppData/Config/Calibre"
+      }
     ],
     "env": [
       {

--- a/Template/template.json
+++ b/Template/template.json
@@ -254,7 +254,7 @@
   {
     "type": 1,
     "title": "Cloudflare DDNS",
-    "name": "cloudflare",
+    "name": "cloudflare-ddns",
     "description": "This small Alpine Linux based Docker image will allow you to use the free CloudFlare DNS Service as a Dynamic DNS Provider (DDNS).",
     "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/cloudflare.png",
     "image": "oznu/cloudflare-ddns",
@@ -266,7 +266,17 @@
     ],
     "platform": "linux",
     "restart_policy": "unless-stopped",
-    "note": "Follow the steps at https://github.com/oznu/docker-cloudflare-ddns#creating-a-cloudflare-api-token to generate a proper API Token for Cloudflare",
+    "env": [
+      {
+        "name": "API_KEY",
+        "label": "API_KEY"
+      },
+      {
+        "name": "ZONE",
+        "label": "ZONE"
+      }
+    ],  
+    "note": "Follow the steps at https://github.com/oznu/docker-cloudflare-ddns#creating-a-cloudflare-api-token to generate a proper API Token for Cloudflare"
   },
   {
     "type": 1,

--- a/Template/template.json
+++ b/Template/template.json
@@ -253,6 +253,23 @@
   },
   {
     "type": 1,
+    "title": "Cloudflare DDNS",
+    "name": "cloudflare",
+    "description": "This small Alpine Linux based Docker image will allow you to use the free CloudFlare DNS Service as a Dynamic DNS Provider (DDNS).",
+    "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/cloudflare.png",
+    "image": "oznu/cloudflare-ddns",
+    "categories": [
+        "DNS",
+        "Cloud",
+        "Other",
+        "Tools"
+    ],
+    "platform": "linux",
+    "restart_policy": "unless-stopped",
+    "note": "Follow the steps at https://github.com/oznu/docker-cloudflare-ddns#creating-a-cloudflare-api-token to generate a proper API Token for Cloudflare",
+  },
+  {
+    "type": 1,
     "title": "EmbyStat",
     "name": "embystat",
     "description": "Embystat is a personal web server that can calculate all kinds of statistics from your (local) Emby server. Just install this on your server and let him calculate all kinds of fun stuff.",

--- a/Template/template.json
+++ b/Template/template.json
@@ -263,9 +263,28 @@
       "Books",
       "Other"
     ],
-    "platform": "linux"
-    "restart-policy": "unless-stopped"
-    
+    "platform": "linux",
+    "restart-policy": "unless-stopped",
+    "ports": [
+      "8080:8080",
+      "8081:8081"
+    ],
+    "volumes": [
+      "container": "/config",
+      "bind": "/portainer/Files/AppData/Config/Calibre"
+    ],
+    "env": [
+      {
+        "name": "PUID",
+        "label": "PUID",
+        "default": "1000"
+      },
+      {
+        "name": "PGID",
+	"label": "PGID",
+	"default": "100"
+      }
+    ]
   },  
   {
     "type": 1,

--- a/Template/template.json
+++ b/Template/template.json
@@ -253,7 +253,7 @@
   },
   {
     "type": 1,
-    "title: "Calibre",
+    "title": "Calibre",
     "name": "calibre",
     "description": "Calibre is a powerful and easy to use e-book manager",
     "logo": "https://raw.githubusercontent.com/SelfhostedPro/selfhosted_templates/master/Images/calibre.png",


### PR DESCRIPTION
This addresses #132 and adds the unofficial Cloudflare DDNS update docker image to the Selfhosted Templates.
This also adresses #158 to add Calibre.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#132: [APP REQUEST]: CloudFlare DDNS](https://issuehunt.io/repos/268890920/issues/132)
- [#158: [APP REQUEST]: Calibre](https://issuehunt.io/repos/268890920/issues/158)
---
</details>
<!-- /Issuehunt content-->