### PR TITLE
Fix Pritunl deployment error

### DIFF
--- a/Template/Stack/pritunl.yml
+++ b/Template/Stack/pritunl.yml
@@ -18,8 +18,6 @@ services:
         - mongo
     network_mode: bridge
     privileged: true
-    sysctls:
-      - net.ipv6.conf.all.disable_ipv6=0
     links:
       - mongo
     volumes:


### PR DESCRIPTION
Fixes #133. The following logs show that the deployment error with Pritunl is to do with the `sysctls` key in the docker-compose.

![](https://user-images.githubusercontent.com/10981005/94999396-feabff80-05b0-11eb-9f2d-59e2698b1187.png)

`sysctls` is not supported in Docker Compose 2.0 which is the only version that Portainer supports so it needs to be removed to work correctly. I've tested the compose file and it works correctly.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#133: [APP REQUEST]: Pritunl with OpenVPN & Wireguard](https://issuehunt.io/repos/268890920/issues/133)
---
</details>
<!-- /Issuehunt content-->