### PR TITLE
Fixing volume paths in stacks

### DIFF
--- a/Template/Stack/nextcloud.yml
+++ b/Template/Stack/nextcloud.yml
@@ -22,7 +22,7 @@ services:
       - PUID=${PUID}
       - PGID=${PGID}
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
-      - TZ=${Timezone}
+      - TZ=${TZ}
       - MYSQL_DATABASE=nextcloud_db
       - MYSQL_USER=nextcloud
       - MYSQL_PASSWORD=${DATABASE_PASSWORD}

--- a/Template/Stack/nextcloud.yml
+++ b/Template/Stack/nextcloud.yml
@@ -27,5 +27,5 @@ services:
       - MYSQL_USER=nextcloud
       - MYSQL_PASSWORD=${DATABASE_PASSWORD}
     volumes:
-      - /portainer/AppData/Config/Nextcloud/DB:/config
+      - /portainer/Files/AppData/Config/Nextcloud/DB:/config
     restart: unless-stopped

--- a/Template/Stack/pritunl.yml
+++ b/Template/Stack/pritunl.yml
@@ -8,7 +8,7 @@ services:
     hostname: pritunldb
     network_mode: bridge
     volumes:
-      - /portainer/AppData/Pritunl/db:/data/db
+      - /portainer/Files/AppData/Pritunl/db:/data/db
 
   pritunl:
     image: goofball222/pritunl:latest

--- a/Template/Stack/seafile.yml
+++ b/Template/Stack/seafile.yml
@@ -8,7 +8,7 @@ services:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
       - MYSQL_LOG_CONSOLE=true
     volumes:
-      - /portainer/AppData/Seafile/db:/var/lib/mysql
+      - /portainer/Files/AppData/Seafile/db:/var/lib/mysql
     networks:
       - seafile-net
 
@@ -26,7 +26,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - /portainer/AppData/Seafile/data:/shared
+      - /portainer/Files/AppData/Seafile/data:/shared
     environment:
       - DB_HOST=db
       - DB_ROOT_PASSWD=${MYSQL_ROOT_PASSWORD}


### PR DESCRIPTION
Not sure if this was intentional or if these folders are used for different purposes, but some stacks used /portainer/Files/AppData and /portainer/AppData, too.
This PR consolidates volume paths to use /portainer/Files/AppData only

`/Files/` was removed here: 
https://github.com/SelfhostedPro/selfhosted_templates/commit/216d62a1a2f0d9fb546c8a16be3c7a026dd02675#diff-3ce630ab79c1f07f5e8c282ee123fc59R30