### PR TITLE
jellyfin: Fix Jellyfin config directory spelling

### DIFF
--- a/Template/template.json
+++ b/Template/template.json
@@ -1414,7 +1414,7 @@
     "volumes": [
       {
         "container": "/config",
-        "bind": "!config/Jelllyfin"
+        "bind": "!config/Jellyfin"
       },
       {
         "container": "/data/tvshows",


### PR DESCRIPTION
This is for the yacht branch.