### PR TITLE
deluge: Use UMASK instead of UMASK_SET

### DIFF
--- a/Template/omv-v1.json
+++ b/Template/omv-v1.json
@@ -781,8 +781,8 @@
           "default": "100"
         },
         {
-          "name": "UMASK_SET",
-          "label": "UMASK_SET",
+          "name": "UMASK",
+          "label": "UMASK",
           "set": "000"
         }
       ]

--- a/Template/omv-v2.json
+++ b/Template/omv-v2.json
@@ -763,8 +763,8 @@
 					"name": "PGID"
 				},
 				{
-					"label": "UMASK_SET",
-					"name": "UMASK_SET",
+					"label": "UMASK",
+					"name": "UMASK",
 					"set": "000"
 				}
 			],

--- a/Template/portainer-v1.json
+++ b/Template/portainer-v1.json
@@ -2064,8 +2064,8 @@
           "default": "100"
         },
         {
-          "name": "UMASK_SET",
-          "label": "UMASK_SET",
+          "name": "UMASK",
+          "label": "UMASK",
           "set": "000"
         }
       ]

--- a/Template/portainer-v2.json
+++ b/Template/portainer-v2.json
@@ -2049,8 +2049,8 @@
 					"name": "PGID"
 				},
 				{
-					"label": "UMASK_SET",
-					"name": "UMASK_SET",
+					"label": "UMASK",
+					"name": "UMASK",
 					"set": "000"
 				}
 			],

--- a/Template/template.json
+++ b/Template/template.json
@@ -2064,8 +2064,8 @@
         "default": "100"
       },
       {
-        "name": "UMASK_SET",
-        "label": "UMASK_SET",
+        "name": "UMASK",
+        "label": "UMASK",
         "set": "000"
       }
     ]

--- a/Template/yacht-arm.yml
+++ b/Template/yacht-arm.yml
@@ -417,8 +417,8 @@
     - name: PGID
       label: PGID
       default: "!PGID"
-    - name: UMASK_SET
-      label: UMASK_SET
+    - name: UMASK
+      label: UMASK
       default: "000"
 
 - type: 1

--- a/Template/yacht.json
+++ b/Template/yacht.json
@@ -816,8 +816,8 @@
           "default": "!PGID"
         },
         {
-          "name": "UMASK_SET",
-          "label": "UMASK_SET",
+          "name": "UMASK",
+          "label": "UMASK",
           "default": "000"
         }
       ]


### PR DESCRIPTION
> You are using a legacy method of defining umask please update your environment variable from UMASK_SET to UMASK to keep the functionality after July 2021.