### PR TITLE
added data persistence to the nextcloud

### DIFF
--- a/Template/Stack/nextcloud.yml
+++ b/Template/Stack/nextcloud.yml
@@ -10,6 +10,7 @@ services:
       - TZ=${TZ}
     volumes:
       - /portainer/Files/AppData/Config/Nextcloud/Config:/config
+      - /portainer/Files/AppData/Config/Nextcloud/Data:/data
     ports:
       - ${PORT}:443
     restart: unless-stopped


### PR DESCRIPTION
following the description and support of linuxserver.io the nextcloud container stores it's users files in the /data directory [...]
i hope nobody is running this bug in prod...