### PR TITLE
Fixed wrong PGID, and added OPENVPN_CONFIG entry

### DIFF
--- a/Template/portainer-v2.json
+++ b/Template/portainer-v2.json
@@ -3929,7 +3929,7 @@
 				{
 					"default": "1001",
 					"label": "PGID",
-					"name": "PUID"
+					"name": "PGID"
 				},
 				{
 					"default": "MULLVAD",
@@ -3944,6 +3944,10 @@
 				{
 					"label": "OPENVPN_PASSWORD",
 					"name": "OPENVPN_PASSWORD"
+				},
+				{
+					"label": "OPENVPN_CONFIG",
+					"name": "OPENVPN_CONFIG"
 				}
 			],
 			"image": "sgtsquiggs/deluge-openvpn:latest",


### PR DESCRIPTION
The PGID was pointing to the PUID, and OPENVPN_CONFIG is required to change the endpoint.